### PR TITLE
Add optgroup possibily for select-control=select and data=json

### DIFF
--- a/site/docs/extensions/filter-control.md
+++ b/site/docs/extensions/filter-control.md
@@ -176,6 +176,7 @@ toc: true
    - `obj:variable.key` to load from a object
    - `url:http://www.example.com/data.json` to load from a remote json file
    - `json:{key:data}` to load from a json string.
+   - `json:{[{'label':'labelOptgroup1',options:data}]}` to load from a json string with `optgroup`
    - `func:functionName` to load from a function.
 
 - **Default:** `undefined`

--- a/site/docs/extensions/filter-control.md
+++ b/site/docs/extensions/filter-control.md
@@ -172,11 +172,11 @@ toc: true
 - **Detail:**
 
    Set custom select filter values, use
-   `var:variable` to load from a variable
-   `obj:variable.key` to load from a object
-   `url:http://www.example.com/data.json` to load from a remote json file
-   `json:{key:data}` to load from a json string.
-   `func:functionName` to load from a function.
+   - `var:variable` to load from a variable
+   - `obj:variable.key` to load from a object
+   - `url:http://www.example.com/data.json` to load from a remote json file
+   - `json:{key:data}` to load from a json string.
+   - `func:functionName` to load from a function.
 
 - **Default:** `undefined`
 


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [x] **New feature** : filter-control select with optgroup
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions** 
  - filtre-control 

<!-- Describe changes from the user side. -->

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
